### PR TITLE
fix: handles non-existing versions when listing

### DIFF
--- a/cf_remote/commands.py
+++ b/cf_remote/commands.py
@@ -27,6 +27,7 @@ from cf_remote.utils import (
     write_json,
     whoami,
     get_package_name,
+    user_error,
 )
 from cf_remote.utils import user_error, is_package_url, print_progress_dot
 from cf_remote.spawn import VM, VMRequest, Providers, AWSCredentials, GCPCredentials
@@ -278,6 +279,9 @@ def install(
 def _iterate_over_packages(tags=None, version=None, edition=None, download=False):
     releases = Releases(edition)
     print("Available releases: {}".format(releases))
+
+    if version not in [rel.version for rel in releases.releases] :
+        user_error(f"CFEngine version '{version}' doesn't exist (yet).")
 
     release = releases.default
     if version:


### PR DESCRIPTION
Command cf-remote --version 1.2.3 list doesn't crash with traceback anymore, but with a custom output instead
